### PR TITLE
Cray-mpich compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,12 @@ set (CMAKE_CXX_EXTENSIONS OFF)
 
 project (plasmabox)
 
+# optimization flags
+#set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall")
+#set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=native -ffast-math -fprofile-generate -fprofile-use")
+#set(CMAKE_CXX_FLAGS_RELEASE "-O2 -march=native -ftree-vectorize -fopt-info-vec")
+#set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=haswell -mtune=haswell") #latest optimization
+
 # set location of python libraries
 set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib)
 

--- a/em-fields/tile.c++
+++ b/em-fields/tile.c++
@@ -676,8 +676,8 @@ void Tile<D>::clear_current()
 // create MPI tag given tile id and extra layer of differentiation
 int get_tag(int cid, int extra_param)
 {
-  assert(extra_param < 100);
-  return cid + extra_param*1e4;
+  assert(extra_param < 10);
+  return cid + extra_param*3e5;
 }
 
 
@@ -693,17 +693,17 @@ std::vector<mpi::request> Tile<D>::send_data( mpi::communicator& comm, int dest,
   std::vector<mpi::request> reqs;
 
   if (tag == 0) {
-    reqs.emplace_back( comm.isend(dest, get_tag(corgi::Tile<D>::cid, 1), yee.jx.data(), yee.jx.size()) );
-    reqs.emplace_back( comm.isend(dest, get_tag(corgi::Tile<D>::cid, 2), yee.jy.data(), yee.jy.size()) );
-    reqs.emplace_back( comm.isend(dest, get_tag(corgi::Tile<D>::cid, 3), yee.jz.data(), yee.jz.size()) );
+    reqs.emplace_back( comm.isend(dest, get_tag(corgi::Tile<D>::cid, 0), yee.jx.data(), yee.jx.size()) );
+    reqs.emplace_back( comm.isend(dest, get_tag(corgi::Tile<D>::cid, 1), yee.jy.data(), yee.jy.size()) );
+    reqs.emplace_back( comm.isend(dest, get_tag(corgi::Tile<D>::cid, 2), yee.jz.data(), yee.jz.size()) );
   } else if (tag == 1) {
-    reqs.emplace_back( comm.isend(dest, get_tag(corgi::Tile<D>::cid, 4), yee.ex.data(), yee.ex.size()) );
-    reqs.emplace_back( comm.isend(dest, get_tag(corgi::Tile<D>::cid, 5), yee.ey.data(), yee.ey.size()) );
-    reqs.emplace_back( comm.isend(dest, get_tag(corgi::Tile<D>::cid, 6), yee.ez.data(), yee.ez.size()) );
+    reqs.emplace_back( comm.isend(dest, get_tag(corgi::Tile<D>::cid, 0), yee.ex.data(), yee.ex.size()) );
+    reqs.emplace_back( comm.isend(dest, get_tag(corgi::Tile<D>::cid, 1), yee.ey.data(), yee.ey.size()) );
+    reqs.emplace_back( comm.isend(dest, get_tag(corgi::Tile<D>::cid, 2), yee.ez.data(), yee.ez.size()) );
   } else if (tag == 2) {
-    reqs.emplace_back( comm.isend(dest, get_tag(corgi::Tile<D>::cid, 7), yee.bx.data(), yee.bx.size()) );
-    reqs.emplace_back( comm.isend(dest, get_tag(corgi::Tile<D>::cid, 8), yee.by.data(), yee.by.size()) );
-    reqs.emplace_back( comm.isend(dest, get_tag(corgi::Tile<D>::cid, 9), yee.bz.data(), yee.bz.size()) );
+    reqs.emplace_back( comm.isend(dest, get_tag(corgi::Tile<D>::cid, 0), yee.bx.data(), yee.bx.size()) );
+    reqs.emplace_back( comm.isend(dest, get_tag(corgi::Tile<D>::cid, 1), yee.by.data(), yee.by.size()) );
+    reqs.emplace_back( comm.isend(dest, get_tag(corgi::Tile<D>::cid, 2), yee.bz.data(), yee.bz.size()) );
   }
 
   return reqs;
@@ -725,17 +725,17 @@ std::vector<mpi::request> Tile<D>::recv_data( mpi::communicator& comm, int orig,
 
 
   if (tag == 0) {
-    reqs.emplace_back( comm.irecv(orig, get_tag(corgi::Tile<D>::cid, 1), yee.jx.data(), yee.jx.size()) );
-    reqs.emplace_back( comm.irecv(orig, get_tag(corgi::Tile<D>::cid, 2), yee.jy.data(), yee.jy.size()) );
-    reqs.emplace_back( comm.irecv(orig, get_tag(corgi::Tile<D>::cid, 3), yee.jz.data(), yee.jz.size()) );
+    reqs.emplace_back( comm.irecv(orig, get_tag(corgi::Tile<D>::cid, 0), yee.jx.data(), yee.jx.size()) );
+    reqs.emplace_back( comm.irecv(orig, get_tag(corgi::Tile<D>::cid, 1), yee.jy.data(), yee.jy.size()) );
+    reqs.emplace_back( comm.irecv(orig, get_tag(corgi::Tile<D>::cid, 2), yee.jz.data(), yee.jz.size()) );
   } else if (tag == 1) {
-    reqs.emplace_back( comm.irecv(orig, get_tag(corgi::Tile<D>::cid, 4), yee.ex.data(), yee.ex.size()) );
-    reqs.emplace_back( comm.irecv(orig, get_tag(corgi::Tile<D>::cid, 5), yee.ey.data(), yee.ey.size()) );
-    reqs.emplace_back( comm.irecv(orig, get_tag(corgi::Tile<D>::cid, 6), yee.ez.data(), yee.ez.size()) );
+    reqs.emplace_back( comm.irecv(orig, get_tag(corgi::Tile<D>::cid, 0), yee.ex.data(), yee.ex.size()) );
+    reqs.emplace_back( comm.irecv(orig, get_tag(corgi::Tile<D>::cid, 1), yee.ey.data(), yee.ey.size()) );
+    reqs.emplace_back( comm.irecv(orig, get_tag(corgi::Tile<D>::cid, 2), yee.ez.data(), yee.ez.size()) );
   } else if (tag == 2) {
-    reqs.emplace_back( comm.irecv(orig, get_tag(corgi::Tile<D>::cid, 7), yee.bx.data(), yee.bx.size()) );
-    reqs.emplace_back( comm.irecv(orig, get_tag(corgi::Tile<D>::cid, 8), yee.by.data(), yee.by.size()) );
-    reqs.emplace_back( comm.irecv(orig, get_tag(corgi::Tile<D>::cid, 9), yee.bz.data(), yee.bz.size()) );
+    reqs.emplace_back( comm.irecv(orig, get_tag(corgi::Tile<D>::cid, 0), yee.bx.data(), yee.bx.size()) );
+    reqs.emplace_back( comm.irecv(orig, get_tag(corgi::Tile<D>::cid, 1), yee.by.data(), yee.by.size()) );
+    reqs.emplace_back( comm.irecv(orig, get_tag(corgi::Tile<D>::cid, 2), yee.bz.data(), yee.bz.size()) );
   }
 
 

--- a/em-fields/tile.c++
+++ b/em-fields/tile.c++
@@ -677,7 +677,7 @@ void Tile<D>::clear_current()
 int get_tag(int cid, int extra_param)
 {
   assert(extra_param < 100);
-  return cid + extra_param*1e6;
+  return cid + extra_param*1e4;
 }
 
 

--- a/em-fields/tile.h
+++ b/em-fields/tile.h
@@ -259,10 +259,10 @@ class Tile :
   void add_analysis_species();
 
   virtual std::vector<mpi::request> 
-  send_data( mpi::communicator&, int orig, int tag) override;
+  send_data( mpi::communicator&, int orig, int mode, int tag) override;
 
   virtual std::vector<mpi::request> 
-  recv_data( mpi::communicator&, int dest, int tag) override;
+  recv_data( mpi::communicator&, int dest, int mode, int tag) override;
 };
 
 

--- a/io/namer.h
+++ b/io/namer.h
@@ -63,7 +63,6 @@ class Namer {
   private:
     const string extension = ".h5";
 
-
   public:
     string name;
 
@@ -76,7 +75,6 @@ class Namer {
     {
       name = prefix + "_" + to_string(lap) + extension;
     }
-
 };
 
 

--- a/io/test_prtcl_writer.c++
+++ b/io/test_prtcl_writer.c++
@@ -31,6 +31,9 @@ h5io::TestPrtclWriter<D>::TestPrtclWriter(
   // corresponding thinning factor is then (approximately)
   stride = n_particles/n_test_particles_approx;
 
+  // avoid under/overflows
+  //stride = stride > NxMesh*NyMesh*NzMesh*ppc ? NxMesh*NyMesh*NzMesh*ppc : stride;
+
   // how many particles would this particular rank have
   int my_n_prtcls = (n_local_tiles*NxMesh*NyMesh*NzMesh*ppc)/stride;
 

--- a/io/test_prtcl_writer.c++
+++ b/io/test_prtcl_writer.c++
@@ -26,10 +26,11 @@ h5io::TestPrtclWriter<D>::TestPrtclWriter(
   //fname = prefix + "-" + to_string(lap) + extension;
 
   // total number of particles
-  int n_particles = Nx*NxMesh*Ny*NyMesh*Nz*NzMesh*ppc;
+  long n_particles = Nx*NxMesh*Ny*NyMesh*Nz*NzMesh*ppc;
 
   // corresponding thinning factor is then (approximately)
-  stride = n_particles/n_test_particles_approx;
+  long lstride = n_particles/((long)n_test_particles_approx);
+  stride = (int) lstride;
 
   // avoid under/overflows
   //stride = stride > NxMesh*NyMesh*NzMesh*ppc ? NxMesh*NyMesh*NzMesh*ppc : stride;

--- a/io/test_prtcl_writer.h
+++ b/io/test_prtcl_writer.h
@@ -36,16 +36,16 @@ class TestPrtclWriter {
 
 
     /// do not consider particles beyond this id
-    int cutoff_id;
+    long cutoff_id;
 
     /// how many time steps to save
     int nt=1;
 
     /// total number of (test) particles
-    int np;
+    long np;
 
     /// how many ranks/categories of particles (second id parameter)
-    int nr;
+    long nr;
 
 
   public:
@@ -54,7 +54,7 @@ class TestPrtclWriter {
     int ispc = 0;
 
     /// data stride length
-    int stride = 1;
+    long stride = 1;
 
     /// constructor that creates a name and creates uniform sampling of particles
     TestPrtclWriter(

--- a/io/writer.h
+++ b/io/writer.h
@@ -56,9 +56,9 @@ class Writer {
     {};
 
     /// Destructor that explicitly closes the file handle
-    ~Writer() {
-      file.~File(); // call destructor explicitly
-    }
+    //~Writer() {
+    //  file.~File(); // call destructor explicitly
+    //}
 
 
     // FIXME: use SFINAE to pick the right specialization without

--- a/pic/particle.h
+++ b/pic/particle.h
@@ -20,7 +20,7 @@ class Particle
 public:
 
   /// actual particle data
-  std::array<double,7> data;
+  std::array<double,7> data = {0.,0.,0.,0.,0.,0.,0.};
 
   /// particle id
   int _id = 0;

--- a/pic/tile.c++
+++ b/pic/tile.c++
@@ -1,5 +1,6 @@
 #include "tile.h"
 #include "communicate.h"
+#include <cmath>
 
 
 namespace pic {
@@ -7,20 +8,23 @@ namespace pic {
 using namespace mpi4cpp;
 
 
-
 // create MPI tag given tile id and extra layer of differentiation
-int get_tag(int cid, int extra_param)
+int get_tag(int tag, int extra_param)
 {
-  assert(extra_param < 10);
-  return cid + extra_param*3e5;
+  assert(extra_param <= 8); // max 8 species
+  assert(tag < (pow(2,16) - 1)); // cray-mpich supports maximum of 2^22-1 tag value
+
+  return tag + (9+extra_param)*pow(2,16);
 }
 
 // create MPI tag for extra communication given tile 
 // id and extra layer of differentiation
-int get_extra_tag(int cid, int extra_param)
+int get_extra_tag(int tag, int extra_param)
 {
-  assert(extra_param < 10);
-  return cid + (extra_param+2)*3e5;
+  assert(extra_param <= 8); // max 8 species
+  assert(tag < (pow(2,16) - 1)); // cray-mpich supports maximum of 2^22-1 tag value
+
+  return tag + (9+8+extra_param)*pow(2,16);
 }
 
 
@@ -98,14 +102,15 @@ template<std::size_t D>
 std::vector<mpi::request> Tile<D>::send_data( 
     mpi::communicator& comm, 
     int dest, 
+    int mode,
     int tag)
 {
-  if     (tag == 0) return fields::Tile<D>::send_data(comm, dest, tag);
-  else if(tag == 1) return fields::Tile<D>::send_data(comm, dest, tag);
-  else if(tag == 2) return fields::Tile<D>::send_data(comm, dest, tag);
+  if     (mode == 0) return fields::Tile<D>::send_data(comm, dest, mode, tag);
+  else if(mode == 1) return fields::Tile<D>::send_data(comm, dest, mode, tag);
+  else if(mode == 2) return fields::Tile<D>::send_data(comm, dest, mode, tag);
 
-  else if(tag == 3) return send_particle_data(comm,dest);
-  else if(tag == 4) return send_particle_extra_data(comm,dest);
+  else if(mode == 3) return send_particle_data(comm,dest,tag);
+  else if(mode == 4) return send_particle_extra_data(comm,dest,tag);
   else assert(false);
 }
 
@@ -113,14 +118,15 @@ std::vector<mpi::request> Tile<D>::send_data(
 template<std::size_t D>
 std::vector<mpi::request> Tile<D>::send_particle_data( 
     mpi::communicator& comm, 
-    int dest)
+    int dest,
+    int tag)
 {
   std::vector<mpi::request> reqs;
   for(size_t ispc=0; ispc<Nspecies(); ispc++) {
     auto& container = get_container(ispc);
 
     reqs.emplace_back(
-        comm.isend(dest, get_tag(corgi::Tile<D>::cid, ispc), 
+        comm.isend(dest, get_tag(tag, ispc), 
           container.outgoing_particles.data(), 
           container.outgoing_particles.size())
         );
@@ -133,7 +139,8 @@ std::vector<mpi::request> Tile<D>::send_particle_data(
 template<std::size_t D>
 std::vector<mpi::request> Tile<D>::send_particle_extra_data( 
     mpi::communicator& comm, 
-    int dest)
+    int dest,
+    int tag)
 {
   std::vector<mpi::request> reqs;
   for(size_t ispc=0; ispc<Nspecies(); ispc++) {
@@ -141,7 +148,7 @@ std::vector<mpi::request> Tile<D>::send_particle_extra_data(
 
     if(!container.outgoing_extra_particles.empty()) {
       reqs.emplace_back(
-          comm.isend(dest, get_extra_tag(corgi::Tile<D>::cid, ispc), 
+          comm.isend(dest, get_extra_tag(tag, ispc), 
             container.outgoing_extra_particles.data(), 
             container.outgoing_extra_particles.size())
           );
@@ -156,14 +163,15 @@ template<std::size_t D>
 std::vector<mpi::request> Tile<D>::recv_data( 
     mpi::communicator& comm, 
     int orig, 
+    int mode,
     int tag)
 {
-  if     (tag == 0) return fields::Tile<D>::recv_data(comm, orig, tag);
-  else if(tag == 1) return fields::Tile<D>::recv_data(comm, orig, tag);
-  else if(tag == 2) return fields::Tile<D>::recv_data(comm, orig, tag);
+  if     (mode == 0) return fields::Tile<D>::recv_data(comm, orig, mode, tag);
+  else if(mode == 1) return fields::Tile<D>::recv_data(comm, orig, mode, tag);
+  else if(mode == 2) return fields::Tile<D>::recv_data(comm, orig, mode, tag);
 
-  else if(tag == 3) return recv_particle_data(comm,orig);
-  else if(tag == 4) return recv_particle_extra_data(comm,orig);
+  else if(mode == 3) return recv_particle_data(comm,orig,tag);
+  else if(mode == 4) return recv_particle_extra_data(comm,orig,tag);
   else assert(false);
 }
 
@@ -171,7 +179,8 @@ std::vector<mpi::request> Tile<D>::recv_data(
 template<std::size_t D>
 std::vector<mpi::request> Tile<D>::recv_particle_data( 
     mpi::communicator& comm, 
-    int orig)
+    int orig,
+    int tag)
 {
   std::vector<mpi::request> reqs;
   for (size_t ispc=0; ispc<Nspecies(); ispc++) {
@@ -179,7 +188,7 @@ std::vector<mpi::request> Tile<D>::recv_particle_data(
     container.incoming_particles.resize( container.optimal_message_size );
 
     reqs.emplace_back(
-        comm.irecv(orig, get_tag(corgi::Tile<D>::cid, ispc),
+        comm.irecv(orig, get_tag(tag, ispc),
           container.incoming_particles.data(),
           container.optimal_message_size)
         );
@@ -192,7 +201,8 @@ std::vector<mpi::request> Tile<D>::recv_particle_data(
 template<std::size_t D>
 std::vector<mpi::request> Tile<D>::recv_particle_extra_data( 
     mpi::communicator& comm, 
-    int orig )
+    int orig,
+    int tag)
 {
   std::vector<mpi::request> reqs;
 
@@ -213,7 +223,7 @@ std::vector<mpi::request> Tile<D>::recv_particle_extra_data(
       container.incoming_extra_particles.resize(extra_size);
 
       reqs.emplace_back(
-          comm.irecv(orig, get_extra_tag(corgi::Tile<D>::cid, ispc),
+          comm.irecv(orig, get_extra_tag(tag, ispc),
             container.incoming_extra_particles.data(),
             extra_size)
           );

--- a/pic/tile.c++
+++ b/pic/tile.c++
@@ -200,10 +200,12 @@ std::vector<mpi::request> Tile<D>::recv_particle_extra_data(
   // and passed.
 
   // normal particles
-  int extra_size;
+  int extra_size=0;
   for (size_t ispc=0; ispc<Nspecies(); ispc++) {
     auto& container = get_container(ispc);
     InfoParticle msginfo(container.incoming_particles[0]);
+
+    //std::cout << "recv_prtcl: got " << msginfo.size() << " by mpi\n";
 
     // check if we need to expect extra message
     extra_size = msginfo.size() - container.optimal_message_size;

--- a/pic/tile.c++
+++ b/pic/tile.c++
@@ -12,7 +12,7 @@ using namespace mpi4cpp;
 int get_tag(int cid, int extra_param)
 {
   assert(extra_param < 10);
-  return cid + extra_param*1e4;
+  return cid + extra_param*3e5;
 }
 
 // create MPI tag for extra communication given tile 
@@ -20,7 +20,7 @@ int get_tag(int cid, int extra_param)
 int get_extra_tag(int cid, int extra_param)
 {
   assert(extra_param < 10);
-  return cid + extra_param*1e5;
+  return cid + (extra_param+2)*3e5;
 }
 
 

--- a/pic/tile.c++
+++ b/pic/tile.c++
@@ -11,16 +11,16 @@ using namespace mpi4cpp;
 // create MPI tag given tile id and extra layer of differentiation
 int get_tag(int cid, int extra_param)
 {
-  assert(extra_param < 100);
-  return cid + extra_param*1e6;
+  assert(extra_param < 10);
+  return cid + extra_param*1e4;
 }
 
 // create MPI tag for extra communication given tile 
 // id and extra layer of differentiation
 int get_extra_tag(int cid, int extra_param)
 {
-  assert(extra_param < 100);
-  return cid + extra_param*1e8;
+  assert(extra_param < 10);
+  return cid + extra_param*1e5;
 }
 
 

--- a/pic/tile.h
+++ b/pic/tile.h
@@ -72,29 +72,29 @@ public:
   //--------------------------------------------------
   // MPI send
   virtual std::vector<mpi::request> 
-  send_data( mpi::communicator&, int orig, int tag) override;
+  send_data( mpi::communicator&, int orig, int mode, int tag) override;
 
   /// actual tag=0 send
   std::vector<mpi::request> 
-  send_particle_data( mpi::communicator&, int orig);
+  send_particle_data( mpi::communicator&, int orig, int tag);
 
   /// actual tag=1 send
   std::vector<mpi::request> 
-  send_particle_extra_data( mpi::communicator&, int orig);
+  send_particle_extra_data( mpi::communicator&, int orig, int tag);
 
 
   //--------------------------------------------------
   // MPI recv
   virtual std::vector<mpi::request> 
-  recv_data(mpi::communicator&, int dest, int tag) override;
+  recv_data(mpi::communicator&, int dest, int mode, int tag) override;
 
   /// actual tag=0 recv
   std::vector<mpi::request> 
-  recv_particle_data(mpi::communicator&, int dest);
+  recv_particle_data(mpi::communicator&, int dest, int tag);
 
   /// actual tag=1 recv
   std::vector<mpi::request> 
-  recv_particle_extra_data(mpi::communicator&, int dest);
+  recv_particle_extra_data(mpi::communicator&, int dest, int tag);
   //--------------------------------------------------
 
 

--- a/vlasov/tasker.h
+++ b/vlasov/tasker.h
@@ -172,7 +172,6 @@ inline void write_mesh(
       = dynamic_cast<vlv::Tile<D>&>(grid.get_tile( cid ));
     writer.write(tile);
   }
-
 }
 
 
@@ -282,7 +281,6 @@ void write_particles(
       = dynamic_cast<pic::Tile<D>&>(grid.get_tile( cid ));
     writer.write(tile);
   }
-
 }
 
 


### PR DESCRIPTION
Cray-mpich does not conform to MPI standard and has a lower limit for maximum tag than other MPI implementations.

This means that tile tag system needs to be redesigned. Probably by splitting main communicator...

Current implementation is a hack to make it work for now.